### PR TITLE
removed bars from images!

### DIFF
--- a/src/components/Renderer/index.js
+++ b/src/components/Renderer/index.js
@@ -654,6 +654,7 @@ const render = function(history) {
       .on('error', function(d) {this.setAttribute('href', d.images.shift());})
       .attr('x', -IMAGE_SIZE / 2)
       .attr('y', -IMAGE_SIZE / 2)
+      .attr('preserveAspectRatio', 'xMidYMin slice')
       .attr('width', IMAGE_SIZE)
       .attr('height', IMAGE_SIZE);
 


### PR DESCRIPTION
this PR:
  - removes the grey bars from the sides of the nodes.

before:
<img width="110" alt="screen shot 2018-05-01 at 11 51 54 am" src="https://user-images.githubusercontent.com/13964123/39480421-20b9cd18-4d36-11e8-96f5-23c9b2c133c7.png">

after:
<img width="125" alt="screen shot 2018-05-01 at 11 51 28 am" src="https://user-images.githubusercontent.com/13964123/39480431-2a01b1f6-4d36-11e8-895b-625e6a0aa26e.png">