### PR TITLE
Fix problem with Search and with node pruning

### DIFF
--- a/src/clients/DBpedia/index.js
+++ b/src/clients/DBpedia/index.js
@@ -116,6 +116,6 @@ const searchByName = (name: string): Promise<Array<SubjectId>> =>
       Array.from(new Set(fp.map(j =>
         mkSubjectFromDBpediaUri(j.person.value))(js.results.bindings))))
 
-export const searchForPeople = (name: string): Promise<Array<PersonDetail>> =>
+export const searchForPeople = (name: string): Promise<Array<?PersonDetail>> =>
   searchByName(name).then(lst => Promise.all(fp.map(getPerson)(lst)))
 

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+import * as fp from 'lodash/fp'
+
 import InfluenceChart from '../InfluenceChart'
 import Navbar from '../Navbar/'
 import WikiCollapse from '../WikiCollapse'
@@ -80,7 +82,8 @@ class App_ extends React.Component<AppProps, AppState> {
   submitSearch(name: string) {
     this.props.setSearchInProgress(true)
     dbpedia.searchForPeople(name)
-      .then(people => this.props.saveSearchResults(name, people))
+      .then((people: Array<?PersonDetail>): void =>
+        this.props.saveSearchResults(name, fp.filter(p => p != null)(people)))
       .catch((err) => {
         this.props.setSearchInProgress(false)
         console.log('Searching failed with an error: ', err)

--- a/src/components/InfluenceChart/index.js
+++ b/src/components/InfluenceChart/index.js
@@ -506,12 +506,15 @@ const updateInfluenceGraph = (
 
   const influencedBy = new Set(focus.influencedBy)
   const influenced = new Set(focus.influenced)
-  const currentIds = union(new Set([focus.id]), influencedBy, influenced)
-  const currentPeople = new Set(fp.compose(
-    influenceLimit,
-    fp.filter(p => p != null),
-    fp.map(id => people[id.asString()]),
-  )(Array.from(currentIds.values())))
+  const currentIds = union(influencedBy, influenced)
+  const currentPeople = union(
+    new Set([focus]),
+    new Set(fp.compose(
+      influenceLimit,
+      fp.filter(p => p != null),
+      fp.map(id => people[id.asString()]),
+    )(Array.from(currentIds.values()))),
+  )
   const oldPeople = new Set(fp.map(n => n.person)(graph.getVisibleNodes()))
 
   const incomingPeople = difference(currentPeople, oldPeople)


### PR DESCRIPTION
The problem with Search is that `getPerson` can fail, which means that `searchForPeople` may have undefined in the resulting list. Flow did not detect this. I make the callers of `searchForPeople` cope with this by changing the return type to `Promise<Array<?PersonDetail>>`.

Certain people can disappear from the display during the node pruning step if they have a very large number of influences and if 25 of those influences are more influential than the focused person. Fixed that by not bothering to add the focus person to the display until all of the pruning is done.