### PR TITLE
make the application respect users clicking on an `/about` link

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,9 @@
+<script>
+  var localStorageKey = 'tsomi-api-key'
+
+  // set the 'we were looking for the about page' flag in localStorage:
+  window.localStorage.setItem(localStorageKey, 'about')
+
+  // redirect the browser to the origin (e.g. the root)
+  window.location.href = window.location.origin
+</script>

--- a/configs/dev-server.js
+++ b/configs/dev-server.js
@@ -1,4 +1,5 @@
 export default {
   debug: true,
   basepath: 'http://localhost:3000',
+  dbpediaRoot: 'http://live.dbpedia.org',
 }

--- a/index.html
+++ b/index.html
@@ -10,6 +10,16 @@
   <body>
     <div id="container"></div>
 
+    <script>
+      var localStorageKey = 'tsomi-api-key'
+
+      // check if the user came here from the "about" page link:
+      var page = window.localStorage.getItem(localStorageKey)
+      if ( page !== null ) {
+        window.history.pushState({}, null, window.location.origin + '/about')
+      } 
+    </script>
+
     <script type="text/javascript" src="js/bundle.js"></script>
 
     <!-- google analytics   -->

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       // check if the user came here from the "about" page link:
       var page = window.localStorage.getItem(localStorageKey)
       if ( page !== null ) {
+        window.localStorage.removeItem(localStorageKey)
         window.history.pushState({}, null, window.location.origin + '/about')
       } 
     </script>

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -74,6 +74,8 @@ class App_ extends React.Component<AppProps, AppState> {
   }
 
   componentDidMount() {
+    if (this.checkIfAboutPage()) this.props.toggleAboutPage()
+
     this.getAndCachePerson_(this.props.focusedSubject).then(
       (person: ?PersonDetail) => {
         if (person !== null && person !== undefined) {
@@ -111,14 +113,16 @@ class App_ extends React.Component<AppProps, AppState> {
       .then((person: ?PersonDetail) => {
         if (person === null || person === undefined) return
 
-        try {
-          window.history.pushState(
-            '',
-            n,
-            `${location.origin}${location.pathname}?subject=${n.asString()}`,
-          )
-        } catch (error) {
-          console.error('Cannot modify window history: ', error)
+        if (!this.props.showAboutPage) {
+          try {
+            window.history.pushState(
+              '',
+              n,
+              `${location.origin}${location.pathname}?subject=${n.asString()}`,
+            )
+          } catch (error) {
+            console.error('Cannot modify window history: ', error)
+          }
         }
         if (person.wikipediaUri) {
           const uri = person.wikipediaUri
@@ -165,14 +169,22 @@ class App_ extends React.Component<AppProps, AppState> {
       })
   }
 
+  checkIfAboutPage() {
+    return window.location.href.includes('/about')
+  }
+
   render() {
     const decoratedToggleAboutPage = () => {
-      const query = window.location.search
+      // this conditional seems backward, because it is. this fn
+      // operates from the "before" state -- if `showAboutPage`
+      // is true, we need to transition to a state wherein
+      // `showAboutPage` is false.
 
-      if (!this.props.showAboutPage) {
-        window.history.pushState({}, '', `/about/${query}`)
+      if (this.props.showAboutPage) {
+        const { id } = this.props.focusedSubject
+        window.history.pushState({}, '', `/?subject=${id}`)
       } else {
-        window.history.pushState({}, '', `/${query}`)
+        window.history.pushState({}, '', `/about`)
       }
 
       this.props.toggleAboutPage()

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -114,15 +114,11 @@ class App_ extends React.Component<AppProps, AppState> {
         if (person === null || person === undefined) return
 
         if (!this.props.showAboutPage) {
-          try {
-            window.history.pushState(
-              '',
-              n,
-              `${location.origin}${location.pathname}?subject=${n.asString()}`,
-            )
-          } catch (error) {
-            console.error('Cannot modify window history: ', error)
-          }
+          window.history.pushState(
+            '',
+            n,
+            `${location.origin}${location.pathname}?subject=${n.asString()}`,
+          )
         }
         if (person.wikipediaUri) {
           const uri = person.wikipediaUri


### PR DESCRIPTION
currently if a user points their browser at `tsomi.cloudcity.io/about/` they get a 404. they should instead be shown the about page of the application. this PR makes that happen.

github pages doesn't allow `.htaccess` files or anything similar, so we needed to exploit something in the way github pages works. when there's no resource found at the url requested, the user is sent to the project's `404.html`.

...our `404.html` just happens to set a flag in `localStorage`, and redirect the browser back to `tsomi.cloudcity.io/`— and the main application is smart enough to pick up on the `localStorage` change and show the about page.